### PR TITLE
added support for a faux parent

### DIFF
--- a/core/components/breadcrumb/elements/snippets/breadcrumb.snippet.php
+++ b/core/components/breadcrumb/elements/snippets/breadcrumb.snippet.php
@@ -51,6 +51,7 @@
  */
 
 // Script Properties
+$fauxParentId         = !empty($fauxParentId) ? $fauxParentId : $modx->getOption('fauxParentId', $scriptProperties, 0, false);
 $from                 = !empty($from) ? $from : $modx->getOption('from', $scriptProperties, 0, true, true);
 $to                   = $currentResourceId = !empty($to) ? $to : $modx->getOption('to', $scriptProperties, $modx->resource->get('id'), true);
 $exclude              = !empty($exclude) ? explode(',', $exclude) : array();
@@ -109,10 +110,16 @@ while ($resourceId != $from && $crumbsCount < $maxCrumbs)
         else {
             $crumbs[] = $resource;
         }
+        
+        //faux parent path
+        $doFauxParent = false;
+        if($crumbsCount == 0 && $fauxParentId){
+            $doFauxParent = true;
+        }
 
         $crumbsCount++;
     }
-    $resourceId = $resource->get('parent');
+    $resourceId = !$doFauxParent ? $resource->get('parent') : $fauxParentId;
 }
 
 // Add home crumb

--- a/core/components/breadcrumb/elements/snippets/breadcrumb.snippet.php
+++ b/core/components/breadcrumb/elements/snippets/breadcrumb.snippet.php
@@ -50,8 +50,11 @@
  * @property maxCrumbTpl - (string) Max delimiter crumb template for BreadCrumb; [Default value : BreadCrumbMaxCrumbTpl].
  */
 
-// Script Properties
+// Added by Adam Smith (enminc)
 $fauxParentId         = !empty($fauxParentId) ? $fauxParentId : $modx->getOption('fauxParentId', $scriptProperties, 0, false);
+
+
+// Script Properties
 $from                 = !empty($from) ? $from : $modx->getOption('from', $scriptProperties, 0, true, true);
 $to                   = $currentResourceId = !empty($to) ? $to : $modx->getOption('to', $scriptProperties, $modx->resource->get('id'), true);
 $exclude              = !empty($exclude) ? explode(',', $exclude) : array();
@@ -110,15 +113,16 @@ while ($resourceId != $from && $crumbsCount < $maxCrumbs)
         else {
             $crumbs[] = $resource;
         }
-        
+
         //faux parent path
         $doFauxParent = false;
-        if($crumbsCount == 0 && $fauxParentId){
+        if($crumbsCount === 0 && is_numeric($fauxParentId)){
             $doFauxParent = true;
         }
 
         $crumbsCount++;
     }
+
     $resourceId = !$doFauxParent ? $resource->get('parent') : $fauxParentId;
 }
 
@@ -148,7 +152,7 @@ foreach($crumbs as $key => $resource)
     elseif ($resource->get('isfolder')
         && ( $resource->get('template') == 0
             || strpos($resource->get('link_attributes'), 'rel="category"') !== false
-            )
+        )
     ) {
         $tpl = $categoryCrumbTpl;
     }
@@ -192,5 +196,3 @@ $output = parseTpl($containerTpl, array(
 ));
 
 return $output;
-
-?>


### PR DESCRIPTION
The use case would be when faking a product into a category for which is does not actually live within. Ex: single product in multiple categories. By allowing the passing of a fauxParentId you can divert the breadcrumb from its original family tree and into another. Result is a breadcrumb path that matches the category you are presenting the product (resource) to be and not the actual path it resides in.
