### PR TITLE
Added [[+position]] placeholder to support schema.org/BreadcrumbList

### DIFF
--- a/core/components/breadcrumb/elements/snippets/breadcrumb.snippet.php
+++ b/core/components/breadcrumb/elements/snippets/breadcrumb.snippet.php
@@ -125,6 +125,7 @@ if ($showHomeCrumb && $resource = $modx->getObject('modResource', $modx->getOpti
 }
 
 // We build the output of crumbs
+$position = 0;
 foreach($crumbs as $key => $resource)
 {
     // Home crumb tpl ?
@@ -161,7 +162,7 @@ foreach($crumbs as $key => $resource)
     } else {
         $link = $modx->makeUrl($resource->get('id'), '', '', $scheme);
     }
-    $placeholders = array_merge($resource->toArray(), array('link' => $link));
+    $placeholders = array_merge($resource->toArray(), array('link' => $link, 'position' => ++$position));
 
     // Output
     $output .= parseTpl($tpl, $placeholders);


### PR DESCRIPTION
In [schema.org/BreadcrumbList](http://schema.org/BreadcrumbList), each element in the breadcrumb list has the required property `position`, to indicate the depth of the item in the breadcrumb list.  Example:

```html
<ol itemscope itemtype="http://schema.org/BreadcrumbList">
  <li itemprop="itemListElement" itemscope
      itemtype="http://schema.org/ListItem">
    <a itemprop="item" href="https://example.com/dresses">
    <span itemprop="name">Dresses</span></a>
    <meta itemprop="position" content="1" />
  </li>
  <li itemprop="itemListElement" itemscope
      itemtype="http://schema.org/ListItem">
    <a itemprop="item" href="https://example.com/dresses/real">
    <span itemprop="name">Real Dresses</span></a>
    <meta itemprop="position" content="2" />
  </li>
</ol>
```
The MODX addon does not support this without adding the `[[+position]]` placeholder (this PR).  The [docs](https://docs.modx.com/extras/revo/breadcrumb/) etc. would have to be updated as well.

Signed-off-by: John Cocula <john@cocula.com>